### PR TITLE
Fix production workflows

### DIFF
--- a/.github/workflows/sleap_cuda_production.yml
+++ b/.github/workflows/sleap_cuda_production.yml
@@ -55,8 +55,8 @@ jobs:
         # https://github.com/docker/build-push-action
         uses: docker/build-push-action@v6
         with:
-          context: ./docker # Build context
-          file: ./docker/Dockerfile # Path to Dockerfile
+          context: ./sleap_cuda # Build context wrt the root of the repository
+          file: ./sleap_cuda/Dockerfile # Path to Dockerfile wrt the root of the repository
           platforms: ${{ matrix.platform }}
           push: true # Push the image to Docker Hub
           # Tags for the production images, including the "latest" tag

--- a/.github/workflows/sleap_vnc_connect_production.yml
+++ b/.github/workflows/sleap_vnc_connect_production.yml
@@ -55,8 +55,8 @@ jobs:
         # https://github.com/docker/build-push-action
         uses: docker/build-push-action@v6
         with:
-          context: ./docker # Build context
-          file: ./docker/Dockerfile # Path to Dockerfile
+          context: ./sleap_vnc_connect # Build context wrt the root of the repository
+          file: ./sleap_vnc_connect/Dockerfile # Path to Dockerfile wrt the root of the repository
           platforms: ${{ matrix.platform }}
           push: true # Push the image to Docker Hub
           # Tags for the production images, including the "latest" tag


### PR DESCRIPTION
Production workflows had incorrect context for Dockerfiles preventing build and push to Dockerhub with `-latest` tags.