### PR TITLE
Run workflows when changes made to workflows

### DIFF
--- a/.github/workflows/sleap_cuda_production.yml
+++ b/.github/workflows/sleap_cuda_production.yml
@@ -7,6 +7,7 @@ on:
       - main
     paths:
       - sleap_cuda/** # Only run on changes to sleap_cuda
+      - .github/workflows/sleap_cuda_production.yml # Only run on changes to this workflow
 
 jobs:
   build:

--- a/.github/workflows/sleap_cuda_test.yml
+++ b/.github/workflows/sleap_cuda_test.yml
@@ -7,6 +7,7 @@ on:
       - main
     paths:
       - sleap_cuda/** # Only run on changes to sleap_cuda
+      - .github/workflows/sleap_cuda_test.yml # Only run on changes to this workflow
 
 jobs:
   build:

--- a/.github/workflows/sleap_vnc_connect_production.yml
+++ b/.github/workflows/sleap_vnc_connect_production.yml
@@ -7,6 +7,7 @@ on:
       - main
     paths:
       - sleap_vnc_connect/** # Only run on changes to sleap_vnc_connect
+      - .github/workflows/sleap_vnc_connect_production.yml # Only run on changes to this workflow
 
 jobs:
   build:

--- a/.github/workflows/sleap_vnc_connect_test.yml
+++ b/.github/workflows/sleap_vnc_connect_test.yml
@@ -7,6 +7,7 @@ on:
       - main
     paths:
       - sleap_vnc_connect/** # Only run on changes to sleap_vnc_connect
+      - .github/workflows/sleap_vnc_connect_test.yml # Only run on changes to this workflow
 
 jobs:
   build:


### PR DESCRIPTION
The workflows themselves should be tested when there are changes made to them. The paths of each workflow is added to trigger each workflow after changes are made (when being run on the relevant branch).