### PR TITLE
Use GitHub container registry

### DIFF
--- a/.github/workflows/sleap_chrome_remote_desktop_production.yml
+++ b/.github/workflows/sleap_chrome_remote_desktop_production.yml
@@ -39,18 +39,15 @@ jobs:
           sanitized_platform="${sanitized_platform/\//-}" # Replace / with -
           echo "sanitized_platform=$sanitized_platform" >> $GITHUB_OUTPUT
 
+      # Step 4: Set up Docker Buildx for multi-architecture builds
       - name: Set up Docker Buildx
-        # https://github.com/docker/setup-buildx-action
         uses: docker/setup-buildx-action@v3
         with:
           driver: docker-container # Use a container driver for Buildx (default)
 
-      - name: Log in to Docker Hub
-        # https://github.com/docker/login-action
-        uses: docker/login-action@v3
-        with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      # Step 5: Authenticate to GitHub Container Registry
+      - name: Authenticate to GitHub Container Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Build and push Docker image
         # https://github.com/docker/build-push-action
@@ -62,8 +59,8 @@ jobs:
           push: true # Push the image to Docker Hub
           # Tags for the production images, including the "latest" tag
           tags: |
-            ${{ vars.DOCKERHUB_USERNAME }}/sleap-chrome-remote-desktop:latest
-            ${{ vars.DOCKERHUB_USERNAME }}/sleap-chrome-remote-desktop:${{ steps.sanitize_platform.outputs.sanitized_platform }}
-            ${{ vars.DOCKERHUB_USERNAME }}/sleap-chrome-remote-desktop:${{ steps.sanitize_platform.outputs.sanitized_platform }}-nvidia-cuda-11.3.1-cudnn8-runtime-ubuntu20.04
-            ${{ vars.DOCKERHUB_USERNAME }}/sleap-chrome-remote-desktop:${{ steps.sanitize_platform.outputs.sanitized_platform }}-sleap-1.3.4
-            ${{ vars.DOCKERHUB_USERNAME }}/sleap-chrome-remote-desktop:${{ steps.sanitize_platform.outputs.sanitized_platform }}-${{ steps.get_sha.outputs.sha }}
+            ghcr.io/${{ github.repository_owner }}/sleap-chrome-remote-desktop:latest
+            ghcr.io/${{ github.repository_owner }}/sleap-chrome-remote-desktop:${{ steps.sanitize_platform.outputs.sanitized_platform }}
+            ghcr.io/${{ github.repository_owner }}/sleap-chrome-remote-desktop:${{ steps.sanitize_platform.outputs.sanitized_platform }}-nvidia-cuda-11.3.1-cudnn8-runtime-ubuntu20.04
+            ghcr.io/${{ github.repository_owner }}/sleap-chrome-remote-desktop:${{ steps.sanitize_platform.outputs.sanitized_platform }}-sleap-1.3.4
+            ghcr.io/${{ github.repository_owner }}/sleap-chrome-remote-desktop:${{ steps.sanitize_platform.outputs.sanitized_platform }}-${{ steps.get_sha.outputs.sha }}

--- a/.github/workflows/sleap_chrome_remote_desktop_test.yml
+++ b/.github/workflows/sleap_chrome_remote_desktop_test.yml
@@ -39,18 +39,15 @@ jobs:
           sanitized_platform="${sanitized_platform/\//-}" # Replace / with -
           echo "sanitized_platform=$sanitized_platform" >> $GITHUB_OUTPUT
 
+      # Step 4: Set up Docker Buildx for multi-architecture builds
       - name: Set up Docker Buildx
-        # https://github.com/docker/setup-buildx-action
         uses: docker/setup-buildx-action@v3
         with:
           driver: docker-container # Use a container driver for Buildx (default)
 
-      - name: Log in to Docker Hub
-        # https://github.com/docker/login-action
-        uses: docker/login-action@v3
-        with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      # Step 5: Authenticate to GitHub Container Registry
+      - name: Authenticate to GitHub Container Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Build and push Docker image
         # https://github.com/docker/build-push-action
@@ -62,7 +59,7 @@ jobs:
           push: true # Push the image to Docker Hub
           # Tags all include "-test" to differentiate from production images
           tags: |
-            ${{ vars.DOCKERHUB_USERNAME }}/sleap-chrome-remote-desktop:${{ steps.sanitize_platform.outputs.sanitized_platform }}-test
-            ${{ vars.DOCKERHUB_USERNAME }}/sleap-chrome-remote-desktop:${{ steps.sanitize_platform.outputs.sanitized_platform }}-nvidia-cuda-11.3.1-cudnn8-runtime-ubuntu20.04-test
-            ${{ vars.DOCKERHUB_USERNAME }}/sleap-chrome-remote-desktop:${{ steps.sanitize_platform.outputs.sanitized_platform }}-sleap-1.3.4-test
-            ${{ vars.DOCKERHUB_USERNAME }}/sleap-chrome-remote-desktop:${{ steps.sanitize_platform.outputs.sanitized_platform }}-${{ steps.get_sha.outputs.sha }}-test
+            ghcr.io/${{ github.repository_owner }}/sleap-chrome-remote-desktop:${{ steps.sanitize_platform.outputs.sanitized_platform }}-test
+            ghcr.io/${{ github.repository_owner }}/sleap-chrome-remote-desktop:${{ steps.sanitize_platform.outputs.sanitized_platform }}-nvidia-cuda-11.3.1-cudnn8-runtime-ubuntu20.04-test
+            ghcr.io/${{ github.repository_owner }}/sleap-chrome-remote-desktop:${{ steps.sanitize_platform.outputs.sanitized_platform }}-sleap-1.3.4-test
+            ghcr.io/${{ github.repository_owner }}/sleap-chrome-remote-desktop:${{ steps.sanitize_platform.outputs.sanitized_platform }}-${{ steps.get_sha.outputs.sha }}-test

--- a/.github/workflows/sleap_cuda_production.yml
+++ b/.github/workflows/sleap_cuda_production.yml
@@ -39,18 +39,15 @@ jobs:
           sanitized_platform="${sanitized_platform/\//-}" # Replace / with -
           echo "sanitized_platform=$sanitized_platform" >> $GITHUB_OUTPUT
 
+      # Step 4: Set up Docker Buildx for multi-architecture builds
       - name: Set up Docker Buildx
-        # https://github.com/docker/setup-buildx-action
         uses: docker/setup-buildx-action@v3
         with:
           driver: docker-container # Use a container driver for Buildx (default)
 
-      - name: Log in to Docker Hub
-        # https://github.com/docker/login-action
-        uses: docker/login-action@v3
-        with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      # Step 5: Authenticate to GitHub Container Registry
+      - name: Authenticate to GitHub Container Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Build and push Docker image
         # https://github.com/docker/build-push-action
@@ -59,11 +56,11 @@ jobs:
           context: ./sleap_cuda # Build context wrt the root of the repository
           file: ./sleap_cuda/Dockerfile # Path to Dockerfile wrt the root of the repository
           platforms: ${{ matrix.platform }}
-          push: true # Push the image to Docker Hub
+          push: true # Push the image to GitHub Container Registry
           # Tags for the production images, including the "latest" tag
           tags: |
-            ${{ vars.DOCKERHUB_USERNAME }}/sleap-cuda:latest
-            ${{ vars.DOCKERHUB_USERNAME }}/sleap-cuda:${{ steps.sanitize_platform.outputs.sanitized_platform }}
-            ${{ vars.DOCKERHUB_USERNAME }}/sleap-cuda:${{ steps.sanitize_platform.outputs.sanitized_platform }}-nvidia-cuda-11.3.1-cudnn8-runtime-ubuntu20.04
-            ${{ vars.DOCKERHUB_USERNAME }}/sleap-cuda:${{ steps.sanitize_platform.outputs.sanitized_platform }}-sleap-1.3.4
-            ${{ vars.DOCKERHUB_USERNAME }}/sleap-cuda:${{ steps.sanitize_platform.outputs.sanitized_platform }}-${{ steps.get_sha.outputs.sha }}
+            ghcr.io/${{ github.repository_owner }}/sleap-cuda:latest
+            ghcr.io/${{ github.repository_owner }}/sleap-cuda:${{ steps.sanitize_platform.outputs.sanitized_platform }}
+            ghcr.io/${{ github.repository_owner }}/sleap-cuda:${{ steps.sanitize_platform.outputs.sanitized_platform }}-nvidia-cuda-11.3.1-cudnn8-runtime-ubuntu20.04
+            ghcr.io/${{ github.repository_owner }}/sleap-cuda:${{ steps.sanitize_platform.outputs.sanitized_platform }}-sleap-1.3.4
+            ghcr.io/${{ github.repository_owner }}/sleap-cuda:${{ steps.sanitize_platform.outputs.sanitized_platform }}-${{ steps.get_sha.outputs.sha }}

--- a/.github/workflows/sleap_cuda_test.yml
+++ b/.github/workflows/sleap_cuda_test.yml
@@ -40,7 +40,7 @@ jobs:
           sanitized_platform="${sanitized_platform/\//-}" # Replace / with -
           echo "sanitized_platform=$sanitized_platform" >> $GITHUB_OUTPUT
 
-      # Step 4: Set up Docker Buildx
+      # Step 4: Set up Docker Buildx for multi-architecture builds
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:

--- a/.github/workflows/sleap_cuda_test.yml
+++ b/.github/workflows/sleap_cuda_test.yml
@@ -20,10 +20,11 @@ jobs:
       git_sha: ${{ steps.get_sha.outputs.sha }}
       sanitized_platform: ${{ steps.sanitize_platform.outputs.sanitized_platform }}
     steps:
+      # Step 1: Checkout the repository
       - name: Checkout code
-        # https://github.com/actions/checkout
         uses: actions/checkout@v4
 
+      # Step 2: Get Git SHA for tagging the image
       - name: Get Git SHA
         id: get_sha
         run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
@@ -31,7 +32,7 @@ jobs:
       - name: Debug Git SHA
         run: echo "Git SHA ${{ steps.get_sha.outputs.sha }}"
 
-      # Generate a sanitized platform string with slashes replaced by dashes
+      # Step 3: Sanitize platform name for tagging
       - name: Sanitize platform name
         id: sanitize_platform
         run: |
@@ -39,30 +40,27 @@ jobs:
           sanitized_platform="${sanitized_platform/\//-}" # Replace / with -
           echo "sanitized_platform=$sanitized_platform" >> $GITHUB_OUTPUT
 
+      # Step 4: Set up Docker Buildx
       - name: Set up Docker Buildx
-        # https://github.com/docker/setup-buildx-action
         uses: docker/setup-buildx-action@v3
         with:
           driver: docker-container # Use a container driver for Buildx (default)
 
-      - name: Log in to Docker Hub
-        # https://github.com/docker/login-action
-        uses: docker/login-action@v3
-        with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      # Step 5: Authenticate to GitHub Container Registry
+      - name: Authenticate to GitHub Container Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
+      # Step 6: Build and push the Docker image to GitHub Container Registry
       - name: Build and push Docker image
-        # https://github.com/docker/build-push-action
         uses: docker/build-push-action@v6
         with:
           context: ./sleap_cuda # Build context wrt the root of the repository
           file: ./sleap_cuda/Dockerfile # Path to Dockerfile wrt the root of the repository
           platforms: ${{ matrix.platform }}
-          push: true # Push the image to Docker Hub
+          push: true # Push the image to GitHub Container Registry
           # Tags all include "-test" to differentiate from production images
           tags: |
-            ${{ vars.DOCKERHUB_USERNAME }}/sleap-cuda:${{ steps.sanitize_platform.outputs.sanitized_platform }}-test
-            ${{ vars.DOCKERHUB_USERNAME }}/sleap-cuda:${{ steps.sanitize_platform.outputs.sanitized_platform }}-nvidia-cuda-11.3.1-cudnn8-runtime-ubuntu20.04-test
-            ${{ vars.DOCKERHUB_USERNAME }}/sleap-cuda:${{ steps.sanitize_platform.outputs.sanitized_platform }}-sleap-1.3.4-test
-            ${{ vars.DOCKERHUB_USERNAME }}/sleap-cuda:${{ steps.sanitize_platform.outputs.sanitized_platform }}-${{ steps.get_sha.outputs.sha }}-test
+            ghcr.io/${{ github.repository_owner }}/sleap-cuda:${{ steps.sanitize_platform.outputs.sanitized_platform }}-test
+            ghcr.io/${{ github.repository_owner }}/sleap-cuda:${{ steps.sanitize_platform.outputs.sanitized_platform }}-nvidia-cuda-11.3.1-cudnn8-runtime-ubuntu20.04-test
+            ghcr.io/${{ github.repository_owner }}/sleap-cuda:${{ steps.sanitize_platform.outputs.sanitized_platform }}-sleap-1.3.4-test
+            ghcr.io/${{ github.repository_owner }}/sleap-cuda:${{ steps.sanitize_platform.outputs.sanitized_platform }}-${{ steps.get_sha.outputs.sha }}-test

--- a/.github/workflows/sleap_vnc_connect_production.yml
+++ b/.github/workflows/sleap_vnc_connect_production.yml
@@ -39,18 +39,15 @@ jobs:
           sanitized_platform="${sanitized_platform/\//-}" # Replace / with -
           echo "sanitized_platform=$sanitized_platform" >> $GITHUB_OUTPUT
 
+      # Step 4: Set up Docker Buildx for multi-architecture builds
       - name: Set up Docker Buildx
-        # https://github.com/docker/setup-buildx-action
         uses: docker/setup-buildx-action@v3
         with:
           driver: docker-container # Use a container driver for Buildx (default)
 
-      - name: Log in to Docker Hub
-        # https://github.com/docker/login-action
-        uses: docker/login-action@v3
-        with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      # Step 5: Authenticate to GitHub Container Registry
+      - name: Authenticate to GitHub Container Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Build and push Docker image
         # https://github.com/docker/build-push-action
@@ -59,11 +56,11 @@ jobs:
           context: ./sleap_vnc_connect # Build context wrt the root of the repository
           file: ./sleap_vnc_connect/Dockerfile # Path to Dockerfile wrt the root of the repository
           platforms: ${{ matrix.platform }}
-          push: true # Push the image to Docker Hub
+          push: true # Push the image to GitHub Container Registry
           # Tags for the production images, including the "latest" tag
           tags: |
-            ${{ vars.DOCKERHUB_USERNAME }}/sleap-vnc-connect:latest
-            ${{ vars.DOCKERHUB_USERNAME }}/sleap-vnc-connect:${{ steps.sanitize_platform.outputs.sanitized_platform }}
-            ${{ vars.DOCKERHUB_USERNAME }}/sleap-vnc-connect:${{ steps.sanitize_platform.outputs.sanitized_platform }}-nvidia-cuda-11.3.1-cudnn8-runtime-ubuntu20.04
-            ${{ vars.DOCKERHUB_USERNAME }}/sleap-vnc-connect:${{ steps.sanitize_platform.outputs.sanitized_platform }}-sleap-1.3.4
-            ${{ vars.DOCKERHUB_USERNAME }}/sleap-vnc-connect:${{ steps.sanitize_platform.outputs.sanitized_platform }}-${{ steps.get_sha.outputs.sha }}
+            ghcr.io/${{ github.repository_owner }}/sleap-vnc-connect:latest
+            ghcr.io/${{ github.repository_owner }}/sleap-vnc-connect:${{ steps.sanitize_platform.outputs.sanitized_platform }}
+            ghcr.io/${{ github.repository_owner }}/sleap-vnc-connect:${{ steps.sanitize_platform.outputs.sanitized_platform }}-nvidia-cuda-11.3.1-cudnn8-runtime-ubuntu20.04
+            ghcr.io/${{ github.repository_owner }}/sleap-vnc-connect:${{ steps.sanitize_platform.outputs.sanitized_platform }}-sleap-1.3.4
+            ghcr.io/${{ github.repository_owner }}/sleap-vnc-connect:${{ steps.sanitize_platform.outputs.sanitized_platform }}-${{ steps.get_sha.outputs.sha }}

--- a/.github/workflows/sleap_vnc_connect_test.yml
+++ b/.github/workflows/sleap_vnc_connect_test.yml
@@ -39,18 +39,15 @@ jobs:
           sanitized_platform="${sanitized_platform/\//-}" # Replace / with -
           echo "sanitized_platform=$sanitized_platform" >> $GITHUB_OUTPUT
 
+      # Step 4: Set up Docker Buildx for multi-architecture builds
       - name: Set up Docker Buildx
-        # https://github.com/docker/setup-buildx-action
         uses: docker/setup-buildx-action@v3
         with:
           driver: docker-container # Use a container driver for Buildx (default)
 
-      - name: Log in to Docker Hub
-        # https://github.com/docker/login-action
-        uses: docker/login-action@v3
-        with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      # Step 5: Authenticate to GitHub Container Registry
+      - name: Authenticate to GitHub Container Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Build and push Docker image
         # https://github.com/docker/build-push-action
@@ -62,7 +59,7 @@ jobs:
           push: true # Push the image to Docker Hub
           # Tags all include "-test" to differentiate from production images
           tags: |
-            ${{ vars.DOCKERHUB_USERNAME }}/sleap-vnc-connect:${{ steps.sanitize_platform.outputs.sanitized_platform }}-test
-            ${{ vars.DOCKERHUB_USERNAME }}/sleap-vnc-connect:${{ steps.sanitize_platform.outputs.sanitized_platform }}-nvidia-cuda-11.3.1-cudnn8-runtime-ubuntu20.04-test
-            ${{ vars.DOCKERHUB_USERNAME }}/sleap-vnc-connect:${{ steps.sanitize_platform.outputs.sanitized_platform }}-sleap-1.3.4-test
-            ${{ vars.DOCKERHUB_USERNAME }}/sleap-vnc-connect:${{ steps.sanitize_platform.outputs.sanitized_platform }}-${{ steps.get_sha.outputs.sha }}-test
+            ghcr.io/${{ github.repository_owner }}/sleap-vnc-connect:${{ steps.sanitize_platform.outputs.sanitized_platform }}-test
+            ghcr.io/${{ github.repository_owner }}/sleap-vnc-connect:${{ steps.sanitize_platform.outputs.sanitized_platform }}-nvidia-cuda-11.3.1-cudnn8-runtime-ubuntu20.04-test
+            ghcr.io/${{ github.repository_owner }}/sleap-vnc-connect:${{ steps.sanitize_platform.outputs.sanitized_platform }}-sleap-1.3.4-test
+            ghcr.io/${{ github.repository_owner }}/sleap-vnc-connect:${{ steps.sanitize_platform.outputs.sanitized_platform }}-${{ steps.get_sha.outputs.sha }}-test

--- a/.github/workflows/sleap_vscode_tunnel_production.yml
+++ b/.github/workflows/sleap_vscode_tunnel_production.yml
@@ -39,18 +39,15 @@ jobs:
           sanitized_platform="${sanitized_platform/\//-}" # Replace / with -
           echo "sanitized_platform=$sanitized_platform" >> $GITHUB_OUTPUT
 
+      # Step 4: Set up Docker Buildx for multi-architecture builds
       - name: Set up Docker Buildx
-        # https://github.com/docker/setup-buildx-action
         uses: docker/setup-buildx-action@v3
         with:
           driver: docker-container # Use a container driver for Buildx (default)
 
-      - name: Log in to Docker Hub
-        # https://github.com/docker/login-action
-        uses: docker/login-action@v3
-        with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      # Step 5: Authenticate to GitHub Container Registry
+      - name: Authenticate to GitHub Container Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Build and push Docker image
         # https://github.com/docker/build-push-action
@@ -59,11 +56,11 @@ jobs:
           context: ./sleap_vscode_tunnel # Build context wrt the root of the repository
           file: ./sleap_vscode_tunnel/Dockerfile # Path to Dockerfile wrt the root of the repository
           platforms: ${{ matrix.platform }}
-          push: true # Push the image to Docker Hub
+          push: true # Push the image to GitHub Container Registry
           # Tags for the production images, including the "latest" tag
           tags: |
-            ${{ vars.DOCKERHUB_USERNAME }}/sleap-vscode-tunnel:latest
-            ${{ vars.DOCKERHUB_USERNAME }}/sleap-vscode-tunnel:${{ steps.sanitize_platform.outputs.sanitized_platform }}
-            ${{ vars.DOCKERHUB_USERNAME }}/sleap-vscode-tunnel:${{ steps.sanitize_platform.outputs.sanitized_platform }}-nvidia-cuda-11.3.1-cudnn8-runtime-ubuntu20.04
-            ${{ vars.DOCKERHUB_USERNAME }}/sleap-vscode-tunnel:${{ steps.sanitize_platform.outputs.sanitized_platform }}-sleap-1.3.4
-            ${{ vars.DOCKERHUB_USERNAME }}/sleap-vscode-tunnel:${{ steps.sanitize_platform.outputs.sanitized_platform }}-${{ steps.get_sha.outputs.sha }}
+            ghcr.io/${{ github.repository_owner }}/sleap-vscode-tunnel:latest
+            ghcr.io/${{ github.repository_owner }}/sleap-vscode-tunnel:${{ steps.sanitize_platform.outputs.sanitized_platform }}
+            ghcr.io/${{ github.repository_owner }}/sleap-vscode-tunnel:${{ steps.sanitize_platform.outputs.sanitized_platform }}-nvidia-cuda-11.3.1-cudnn8-runtime-ubuntu20.04
+            ghcr.io/${{ github.repository_owner }}/sleap-vscode-tunnel:${{ steps.sanitize_platform.outputs.sanitized_platform }}-sleap-1.3.4
+            ghcr.io/${{ github.repository_owner }}/sleap-vscode-tunnel:${{ steps.sanitize_platform.outputs.sanitized_platform }}-${{ steps.get_sha.outputs.sha }}

--- a/.github/workflows/sleap_vscode_tunnel_test.yml
+++ b/.github/workflows/sleap_vscode_tunnel_test.yml
@@ -39,18 +39,15 @@ jobs:
           sanitized_platform="${sanitized_platform/\//-}" # Replace / with -
           echo "sanitized_platform=$sanitized_platform" >> $GITHUB_OUTPUT
 
+      # Step 4: Set up Docker Buildx for multi-architecture builds
       - name: Set up Docker Buildx
-        # https://github.com/docker/setup-buildx-action
         uses: docker/setup-buildx-action@v3
         with:
           driver: docker-container # Use a container driver for Buildx (default)
 
-      - name: Log in to Docker Hub
-        # https://github.com/docker/login-action
-        uses: docker/login-action@v3
-        with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      # Step 5: Authenticate to GitHub Container Registry
+      - name: Authenticate to GitHub Container Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Build and push Docker image
         # https://github.com/docker/build-push-action
@@ -59,10 +56,10 @@ jobs:
           context: ./sleap_vscode_tunnel # Build context wrt the root of the repository
           file: ./sleap_vscode_tunnel/Dockerfile # Path to Dockerfile wrt the root of the repository
           platforms: ${{ matrix.platform }}
-          push: true # Push the image to Docker Hub
+          push: true # Push the image to GitHub Container Registry
           # Tags all include "-test" to differentiate from production images
           tags: |
-            ${{ vars.DOCKERHUB_USERNAME }}/sleap-vscode-tunnel:${{ steps.sanitize_platform.outputs.sanitized_platform }}-test
-            ${{ vars.DOCKERHUB_USERNAME }}/sleap-vscode-tunnel:${{ steps.sanitize_platform.outputs.sanitized_platform }}-nvidia-cuda-11.3.1-cudnn8-runtime-ubuntu20.04-test
-            ${{ vars.DOCKERHUB_USERNAME }}/sleap-vscode-tunnel:${{ steps.sanitize_platform.outputs.sanitized_platform }}-sleap-1.3.4-test
-            ${{ vars.DOCKERHUB_USERNAME }}/sleap-vscode-tunnel:${{ steps.sanitize_platform.outputs.sanitized_platform }}-${{ steps.get_sha.outputs.sha }}-test
+            ghcr.io/${{ github.repository_owner }}/sleap-vscode-tunnel:${{ steps.sanitize_platform.outputs.sanitized_platform }}-test
+            ghcr.io/${{ github.repository_owner }}/sleap-vscode-tunnel:${{ steps.sanitize_platform.outputs.sanitized_platform }}-nvidia-cuda-11.3.1-cudnn8-runtime-ubuntu20.04-test
+            ghcr.io/${{ github.repository_owner }}/sleap-vscode-tunnel:${{ steps.sanitize_platform.outputs.sanitized_platform }}-sleap-1.3.4-test
+            ghcr.io/${{ github.repository_owner }}/sleap-vscode-tunnel:${{ steps.sanitize_platform.outputs.sanitized_platform }}-${{ steps.get_sha.outputs.sha }}-test


### PR DESCRIPTION
- workflows are updated to use a Github Token in the action to push the container to the github container registry associated with this repo.
- after actions are complete, images are available at https://github.com/orgs/talmolab/packages?repo_name=sleap-cuda-container
- instructions followed from https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#upgrading-a-workflow-that-accesses-a-registry-using-a-personal-access-token, https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-to-the-container-registry, and https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow