### PR TITLE
Change Port argument to 80 in the `start.sh` for Lablink's Client Image

### DIFF
--- a/lablink_sleap_client_image/start.sh
+++ b/lablink_sleap_client_image/start.sh
@@ -4,7 +4,6 @@ echo "Starting the lablink sleap client container..."
 
 echo "ALLOCATOR_HOST: $ALLOCATOR_HOST"
 echo "TUTORIAL_REPO_TO_CLONE: $TUTORIAL_REPO_TO_CLONE"
-echo "ALLOCATOR_PORT: $ALLOCATOR_PORT"
 
 if [ -n "$TUTORIAL_REPO_TO_CLONE" ]; then
   mkdir -p /home/client/Desktop
@@ -24,7 +23,7 @@ fi
 echo "Running subscribe script..."
 
 # Activate the conda environment and run the subscribe script
-subscribe allocator.host=$ALLOCATOR_HOST allocator.port=$ALLOCATOR_PORT
+subscribe allocator.host=$ALLOCATOR_HOST allocator.port=80
 
 # Keep the container alive
 tail -f /dev/null

--- a/lablink_sleap_client_image/start.sh
+++ b/lablink_sleap_client_image/start.sh
@@ -4,6 +4,7 @@ echo "Starting the lablink sleap client container..."
 
 echo "ALLOCATOR_HOST: $ALLOCATOR_HOST"
 echo "TUTORIAL_REPO_TO_CLONE: $TUTORIAL_REPO_TO_CLONE"
+echo "ALLOCATOR_PORT: $ALLOCATOR_PORT"
 
 if [ -n "$TUTORIAL_REPO_TO_CLONE" ]; then
   mkdir -p /home/client/Desktop
@@ -23,7 +24,7 @@ fi
 echo "Running subscribe script..."
 
 # Activate the conda environment and run the subscribe script
-subscribe allocator.host=$ALLOCATOR_HOST
+subscribe allocator.host=$ALLOCATOR_HOST allocator.port=$ALLOCATOR_PORT
 
 # Keep the container alive
 tail -f /dev/null


### PR DESCRIPTION
This PR updates the `lablink_sleap_client_image/start.sh` script to include support for specifying the allocator port when running the container. The changes enhance configurability and ensure the port is passed correctly to the subscription script.