### PR TITLE
Add Chrome Browser to LabLink Client for SLEAP

### DIFF
--- a/lablink_sleap_client_image/Dockerfile
+++ b/lablink_sleap_client_image/Dockerfile
@@ -104,10 +104,6 @@ RUN python3 -m pip install lablink-client-service
 USER ${USERNAME}
 WORKDIR /home/${USERNAME}
 
-# Configure Chrome to run without sandboxing
-RUN echo '#!/bin/bash\nexec /opt/google/chrome/google-chrome --no-sandbox "$@"' > /usr/local/bin/google-chrome && \
-    sudo chmod +x /usr/local/bin/google-chrome
-
 # Copy the startup script
 COPY start.sh /home/${USERNAME}/start.sh
 RUN sudo chmod +x /home/${USERNAME}/start.sh


### PR DESCRIPTION
This pull request modifies the Dockerfile for the `lablink_sleap_client_image` to add support for Google Chrome in a containerized environment. Key changes include installing Google Chrome, configuring it to run without sandboxing, and removing Firefox installation.

### Google Chrome Integration:
* Added necessary dependencies (`wget`, `xdg-utils`, `fonts-liberation`, `libasound2`) to support Google Chrome installation.
* Installed Google Chrome using the official `.deb` package and configured it to run without sandboxing for compatibility with Chrome Remote Desktop. Created wrapper scripts for `google-chrome` and `google-chrome-stable` to enforce the `--no-sandbox` flag.

### Removal of Firefox:
* Removed the installation of Firefox from the Dockerfile, transitioning exclusively to Google Chrome for browser functionality.