### PR TITLE
Update lablink-client-service to version 0.0.8a0

### DIFF
--- a/lablink_sleap_client_image/Dockerfile
+++ b/lablink_sleap_client_image/Dockerfile
@@ -98,7 +98,7 @@ RUN usermod -aG chrome-remote-desktop ${USERNAME}
 RUN chmod -R a+w /usr/local/lib/python3.8/dist-packages
 
 # Pip install client service package
-RUN python3 -m pip install lablink-client-service==0.0.4
+RUN python3 -m pip install lablink-client-service==0.0.8a0
 
 # Switch to non-root user for Google Chrome Remote Desktop to work.
 USER ${USERNAME}


### PR DESCRIPTION
## Summary
- Updated `lablink-client-service` from version 0.0.4 to 0.0.8a0 in the lablink_sleap_client_image/Dockerfile

## Test plan
- [ ] Build the Docker image to verify the installation succeeds
- [ ] Test the client service functionality with the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)