### PR TITLE
Add New Image for LabLink Client with the Latest SLEAP

### DIFF
--- a/.github/workflows/lablink_sleap_latest_client_production.yml
+++ b/.github/workflows/lablink_sleap_latest_client_production.yml
@@ -1,0 +1,63 @@
+name: Build and Push lablink-latest-sleap-client (Test Workflow)
+
+# Run on push to branches other than main for lablink_sleap_client_image
+on:
+    push:
+        branches:
+            - main
+        paths:
+            - lablink_sleap_latest_client/** # Only run on changes to lablink_sleap_latest_client
+            - .github/workflows/lablink_sleap_latest_client_test.yml # Only run on changes to this workflow
+
+jobs:
+    build:
+        runs-on: ubuntu-latest # Only build on Ubuntu for now since Docker is not available on macOS runners
+        strategy:
+            matrix:
+                platform: [linux/amd64] # Only build amd64 for now
+            max-parallel: 2 # Build both architectures in parallel (if more than one)
+        outputs:
+            git_sha: ${{ steps.get_sha.outputs.sha }}
+            sanitized_platform: ${{ steps.sanitize_platform.outputs.sanitized_platform }}
+        steps:
+            - name: Checkout code
+              # https://github.com/actions/checkout
+              uses: actions/checkout@v4
+
+            - name: Get Git SHA
+              id: get_sha
+              run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
+            - name: Debug Git SHA
+              run: echo "Git SHA ${{ steps.get_sha.outputs.sha }}"
+
+            # Generate a sanitized platform string with slashes replaced by dashes
+            - name: Sanitize platform name
+              id: sanitize_platform
+              run: |
+                  sanitized_platform="${{ matrix.platform }}" # Copy platform value
+                  sanitized_platform="${sanitized_platform/\//-}" # Replace / with -
+                  echo "sanitized_platform=$sanitized_platform" >> $GITHUB_OUTPUT
+
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v3
+              with:
+                  driver: docker-container # Use a container driver for Buildx (default)
+
+            - name: Authenticate to GitHub Container Registry
+              run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+            - name: Build and push Docker image
+              # https://github.com/docker/build-push-action
+              uses: docker/build-push-action@v6
+              with:
+                  context: ./lablink_sleap_latest_client # Build context wrt the root of the repository
+                  file: ./lablink_sleap_latest_client/Dockerfile # Path to Dockerfile wrt the root of the repository
+                  platforms: ${{ matrix.platform }}
+                  push: true # Push the image to Docker Hub
+                  # Tags all include "-test" to differentiate from production images
+                  tags: |
+                      ghcr.io/${{ github.repository_owner }}/lablink-latest-sleap-client-image:${{ steps.sanitize_platform.outputs.sanitized_platform }}
+                      ghcr.io/${{ github.repository_owner }}/lablink-latest-sleap-client-image:${{ steps.sanitize_platform.outputs.sanitized_platform }}-nvidia-cuda-11.3.1-cudnn8-runtime-ubuntu20.04
+                      ghcr.io/${{ github.repository_owner }}/lablink-latest-sleap-client-image:${{ steps.sanitize_platform.outputs.sanitized_platform }}-sleap-1.5.2
+                      ghcr.io/${{ github.repository_owner }}/lablink-latest-sleap-client-image:${{ steps.sanitize_platform.outputs.sanitized_platform }}-${{ steps.get_sha.outputs.sha }}

--- a/.github/workflows/lablink_sleap_latest_client_production.yml
+++ b/.github/workflows/lablink_sleap_latest_client_production.yml
@@ -1,63 +1,62 @@
 name: Build and Push lablink-latest-sleap-client (Test Workflow)
 
-# Run on push to branches other than main for lablink_sleap_client_image
+# Run on push to main branch for lablink_sleap_client_image
 on:
-    push:
-        branches:
-            - main
-        paths:
-            - lablink_sleap_latest_client/** # Only run on changes to lablink_sleap_latest_client
-            - .github/workflows/lablink_sleap_latest_client_test.yml # Only run on changes to this workflow
+  push:
+    branches:
+      - main
+    paths:
+      - lablink_sleap_latest_client/** # Only run on changes to lablink_sleap_latest_client
+      - .github/workflows/lablink_sleap_latest_client_production.yml # Only run on changes to this workflow
 
 jobs:
-    build:
-        runs-on: ubuntu-latest # Only build on Ubuntu for now since Docker is not available on macOS runners
-        strategy:
-            matrix:
-                platform: [linux/amd64] # Only build amd64 for now
-            max-parallel: 2 # Build both architectures in parallel (if more than one)
-        outputs:
-            git_sha: ${{ steps.get_sha.outputs.sha }}
-            sanitized_platform: ${{ steps.sanitize_platform.outputs.sanitized_platform }}
-        steps:
-            - name: Checkout code
-              # https://github.com/actions/checkout
-              uses: actions/checkout@v4
+  build:
+    runs-on: ubuntu-latest # Only build on Ubuntu for now since Docker is not available on macOS runners
+    strategy:
+      matrix:
+        platform: [linux/amd64] # Only build amd64 for now
+      max-parallel: 2 # Build both architectures in parallel (if more than one)
+    outputs:
+      git_sha: ${{ steps.get_sha.outputs.sha }}
+      sanitized_platform: ${{ steps.sanitize_platform.outputs.sanitized_platform }}
+    steps:
+      - name: Checkout code
+        # https://github.com/actions/checkout
+        uses: actions/checkout@v4
 
-            - name: Get Git SHA
-              id: get_sha
-              run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+      - name: Get Git SHA
+        id: get_sha
+        run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
-            - name: Debug Git SHA
-              run: echo "Git SHA ${{ steps.get_sha.outputs.sha }}"
+      - name: Debug Git SHA
+        run: echo "Git SHA ${{ steps.get_sha.outputs.sha }}"
 
-            # Generate a sanitized platform string with slashes replaced by dashes
-            - name: Sanitize platform name
-              id: sanitize_platform
-              run: |
-                  sanitized_platform="${{ matrix.platform }}" # Copy platform value
-                  sanitized_platform="${sanitized_platform/\//-}" # Replace / with -
-                  echo "sanitized_platform=$sanitized_platform" >> $GITHUB_OUTPUT
+      # Generate a sanitized platform string with slashes replaced by dashes
+      - name: Sanitize platform name
+        id: sanitize_platform
+        run: |
+          sanitized_platform="${{ matrix.platform }}" # Copy platform value
+          sanitized_platform="${sanitized_platform/\//-}" # Replace / with -
+          echo "sanitized_platform=$sanitized_platform" >> $GITHUB_OUTPUT
 
-            - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v3
-              with:
-                  driver: docker-container # Use a container driver for Buildx (default)
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker-container # Use a container driver for Buildx (default)
 
-            - name: Authenticate to GitHub Container Registry
-              run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Authenticate to GitHub Container Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
-            - name: Build and push Docker image
-              # https://github.com/docker/build-push-action
-              uses: docker/build-push-action@v6
-              with:
-                  context: ./lablink_sleap_latest_client # Build context wrt the root of the repository
-                  file: ./lablink_sleap_latest_client/Dockerfile # Path to Dockerfile wrt the root of the repository
-                  platforms: ${{ matrix.platform }}
-                  push: true # Push the image to Docker Hub
-                  # Tags all include "-test" to differentiate from production images
-                  tags: |
-                      ghcr.io/${{ github.repository_owner }}/lablink-latest-sleap-client-image:${{ steps.sanitize_platform.outputs.sanitized_platform }}
-                      ghcr.io/${{ github.repository_owner }}/lablink-latest-sleap-client-image:${{ steps.sanitize_platform.outputs.sanitized_platform }}-nvidia-cuda-11.3.1-cudnn8-runtime-ubuntu20.04
-                      ghcr.io/${{ github.repository_owner }}/lablink-latest-sleap-client-image:${{ steps.sanitize_platform.outputs.sanitized_platform }}-sleap-1.5.2
-                      ghcr.io/${{ github.repository_owner }}/lablink-latest-sleap-client-image:${{ steps.sanitize_platform.outputs.sanitized_platform }}-${{ steps.get_sha.outputs.sha }}
+      - name: Build and push Docker image
+        # https://github.com/docker/build-push-action
+        uses: docker/build-push-action@v6
+        with:
+          context: ./lablink_sleap_latest_client # Build context wrt the root of the repository
+          file: ./lablink_sleap_latest_client/Dockerfile # Path to Dockerfile wrt the root of the repository
+          platforms: ${{ matrix.platform }}
+          push: true # Push the image to Docker Hub
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/lablink-latest-sleap-client-image:${{ steps.sanitize_platform.outputs.sanitized_platform }}
+            ghcr.io/${{ github.repository_owner }}/lablink-latest-sleap-client-image:${{ steps.sanitize_platform.outputs.sanitized_platform }}-nvidia-cuda-12.8.1-cudnn8-runtime-ubuntu22.04
+            ghcr.io/${{ github.repository_owner }}/lablink-latest-sleap-client-image:${{ steps.sanitize_platform.outputs.sanitized_platform }}-sleap-1.5.2
+            ghcr.io/${{ github.repository_owner }}/lablink-latest-sleap-client-image:${{ steps.sanitize_platform.outputs.sanitized_platform }}-${{ steps.get_sha.outputs.sha }}

--- a/.github/workflows/lablink_sleap_latest_client_test.yml
+++ b/.github/workflows/lablink_sleap_latest_client_test.yml
@@ -44,6 +44,15 @@ jobs:
         with:
           driver: docker-container # Use a container driver for Buildx (default)
 
+      - name: Free up disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/share/boost
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          sudo docker system prune -af
+          df -h
+
       - name: Authenticate to GitHub Container Registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 

--- a/.github/workflows/lablink_sleap_latest_client_test.yml
+++ b/.github/workflows/lablink_sleap_latest_client_test.yml
@@ -1,0 +1,63 @@
+name: Build and Push lablink-latest-sleap-client (Test Workflow)
+
+# Run on push to branches other than main for lablink_sleap_client_image
+on:
+  push:
+    branches-ignore:
+      - main
+    paths:
+      - lablink_sleap_latest_client/** # Only run on changes to lablink_sleap_latest_client
+      - .github/workflows/lablink_sleap_latest_client_test.yml # Only run on changes to this workflow
+
+jobs:
+  build:
+    runs-on: ubuntu-latest # Only build on Ubuntu for now since Docker is not available on macOS runners
+    strategy:
+      matrix:
+        platform: [linux/amd64] # Only build amd64 for now
+      max-parallel: 2 # Build both architectures in parallel (if more than one)
+    outputs:
+      git_sha: ${{ steps.get_sha.outputs.sha }}
+      sanitized_platform: ${{ steps.sanitize_platform.outputs.sanitized_platform }}
+    steps:
+      - name: Checkout code
+        # https://github.com/actions/checkout
+        uses: actions/checkout@v4
+
+      - name: Get Git SHA
+        id: get_sha
+        run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Debug Git SHA
+        run: echo "Git SHA ${{ steps.get_sha.outputs.sha }}"
+
+      # Generate a sanitized platform string with slashes replaced by dashes
+      - name: Sanitize platform name
+        id: sanitize_platform
+        run: |
+          sanitized_platform="${{ matrix.platform }}" # Copy platform value
+          sanitized_platform="${sanitized_platform/\//-}" # Replace / with -
+          echo "sanitized_platform=$sanitized_platform" >> $GITHUB_OUTPUT
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker-container # Use a container driver for Buildx (default)
+
+      - name: Authenticate to GitHub Container Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Build and push Docker image
+        # https://github.com/docker/build-push-action
+        uses: docker/build-push-action@v6
+        with:
+          context: ./lablink_sleap_latest_client # Build context wrt the root of the repository
+          file: ./lablink_sleap_latest_client/Dockerfile # Path to Dockerfile wrt the root of the repository
+          platforms: ${{ matrix.platform }}
+          push: true # Push the image to Docker Hub
+          # Tags all include "-test" to differentiate from production images
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/lablink-latest-sleap-client-image:${{ steps.sanitize_platform.outputs.sanitized_platform }}-test
+            ghcr.io/${{ github.repository_owner }}/lablink-latest-sleap-client-image:${{ steps.sanitize_platform.outputs.sanitized_platform }}-nvidia-cuda-11.3.1-cudnn8-runtime-ubuntu20.04-test
+            ghcr.io/${{ github.repository_owner }}/lablink-latest-sleap-client-image:${{ steps.sanitize_platform.outputs.sanitized_platform }}-sleap-1.5.2-test
+            ghcr.io/${{ github.repository_owner }}/lablink-latest-sleap-client-image:${{ steps.sanitize_platform.outputs.sanitized_platform }}-${{ steps.get_sha.outputs.sha }}-test

--- a/lablink_sleap_latest_client/.devcontainer/devcontainer.json
+++ b/lablink_sleap_latest_client/.devcontainer/devcontainer.json
@@ -1,0 +1,17 @@
+{
+  "name": "Lablink SLEAP v1.5.1 Client Devcontainer",
+  "build": {
+    "context": "..",
+    "dockerfile": "../Dockerfile"
+  },
+  "runArgs": ["--gpus=all"],
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash"
+      }
+    }
+  },
+  "postCreateCommand": "echo 'Devcontainer ready for use!'",
+  "remoteUser": "root"
+}

--- a/lablink_sleap_latest_client/.devcontainer/devcontainer.json
+++ b/lablink_sleap_latest_client/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "name": "Lablink SLEAP v1.5.1 Client Devcontainer",
+  "name": "Lablink SLEAP v1.5.2 Client Devcontainer",
   "build": {
     "context": "..",
     "dockerfile": "../Dockerfile"

--- a/lablink_sleap_latest_client/.dockerignore
+++ b/lablink_sleap_latest_client/.dockerignore
@@ -1,0 +1,19 @@
+# Ignore Python cache
+__pycache__/
+*.pyc
+*.pyo
+
+# Ignore virtual environments
+env/
+venv/
+
+# Ignore version control and logs
+.git/
+*.log
+
+# Ignore Docker build artifacts
+docker/*.tmp
+
+README.md
+.gitignore
+terraform/*

--- a/lablink_sleap_latest_client/Dockerfile
+++ b/lablink_sleap_latest_client/Dockerfile
@@ -5,6 +5,10 @@ WORKDIR /home/client
 
 ARG PACKAGE_VERSION=0.0.8a0
 
+# Compile Python bytecode
+# https://docs.astral.sh/uv/guides/integration/docker/#compiling-bytecode
+ENV UV_COMPILE_BYTECODE=1
+
 # Since sleap requires python >=3.11, we need to create a new venv with that version
 # and install both sleap and lablink-client-service into that venv.
 RUN uv python install 3.11 \

--- a/lablink_sleap_latest_client/Dockerfile
+++ b/lablink_sleap_latest_client/Dockerfile
@@ -3,5 +3,16 @@ FROM ghcr.io/talmolab/lablink-client-base-image:linux-amd64-latest
 USER client
 WORKDIR /home/client
 
-RUN uv venv /home/client/.venv && \
-    uv pip install --python=/home/client/.venv/bin/python sleap[nn]==1.5.2
+ARG PACKAGE_VERSION=0.0.8a0
+
+# Since sleap requires python >=3.11, we need to create a new venv with that version
+# and install both sleap and lablink-client-service into that venv.
+RUN uv python install 3.11 \
+ && rm -rf /home/client/.venv \
+ && uv venv --python="$(uv python find 3.11)" /home/client/.venv \
+ && uv pip install --python=/home/client/.venv/bin/python \
+      "lablink-client-service==${PACKAGE_VERSION}" \
+ && uv pip install --python=/home/client/.venv/bin/python \
+      'sleap[nn]==1.5.2' \
+      --index https://download.pytorch.org/whl/cu128 \
+      --index https://pypi.org/simple

--- a/lablink_sleap_latest_client/Dockerfile
+++ b/lablink_sleap_latest_client/Dockerfile
@@ -15,4 +15,5 @@ RUN uv python install 3.11 \
  && uv pip install --python=/home/client/.venv/bin/python \
       'sleap[nn]==1.5.2' \
       --index https://download.pytorch.org/whl/cu128 \
-      --index https://pypi.org/simple
+      --index https://pypi.org/simple \
+      --no-cache

--- a/lablink_sleap_latest_client/Dockerfile
+++ b/lablink_sleap_latest_client/Dockerfile
@@ -1,0 +1,7 @@
+FROM ghcr.io/talmolab/lablink-client-base-image:linux-amd64-latest
+
+USER client
+WORKDIR /home/client
+
+RUN uv venv /home/client/.venv && \
+    uv pip install --python=/home/client/.venv/bin/python sleap[nn]==1.5.2

--- a/lablink_sleap_latest_client/README.md
+++ b/lablink_sleap_latest_client/README.md
@@ -1,0 +1,103 @@
+# Lablink SLEAP v1.5.2 Client Image
+
+This directory contains the Dockerfile and related configuration for building a Docker image that includes SLEAP v1.5.2 and the `lablink-client-service` for LabLink.
+
+## Image Details
+
+- **Base Image:** `ghcr.io/talmolab/lablink-client-base-image:linux-amd64-latest`
+- **Python Version:** 3.11
+- **Key Packages:**
+  - `lablink-client-service==0.0.8a0`
+  - `sleap[nn]==1.5.2`
+- **CUDA Version:** This image is built for CUDA 12.8, as indicated by the PyTorch index used.
+
+## Installation
+
+**Make sure to have Docker Daemon running first**
+
+You can pull the image if you don't have it built locally, or need to update the latest, with
+
+```
+docker pull ghcr.io/talmolab/lablink-latest-sleap-image:latest
+```
+
+## Usage
+
+Then, to run the image with gpus interactively:
+
+```
+docker run --gpus all -it ghcr.io/talmolab/lablink-latest-sleap-image:latest bash
+```
+
+and test with
+
+```
+uv run python -c "import sleap; sleap.versions()" && nvidia-smi
+```
+
+In general, use the syntax
+
+```
+docker run -v /path/on/host:/path/in/container [other options] image_name [command]
+```
+
+Note that host paths are absolute.
+
+Use this syntax to give host permissions to mounted volumes
+
+```
+docker run -u $(id -u):$(id -g) -v /your/host/directory:/container/directory [options] your-image-name [command]
+```
+
+```
+docker run -u $(id -u):$(id -g) -v ./tests/data:/tests/data --gpus all -it ghcr.io/talmolab/lablink-latest-sleap-image:latest bash
+```
+
+**Notes:**
+
+- The `ghcr.io/talmolab/sleap-v151-cuda` is the Docker registry where the images are pulled from. This is only used when pulling images from the cloud, and not necesary when building/running locally.
+- `-it` ensures that you get an interactive terminal. The `i` stands for interactive, and `t` allocates a pseudo-TTY, which is what allows you to interact with the bash shell inside the container.
+- The `-v` or `--volume` option mounts the specified directory with the same level of access as the directory has on the host.
+- `bash` is the command that gets executed inside the container, which in this case is to start the bash shell.
+- Order of operations is 1. Pull (if needed): Get a pre-built image from a registry. 2. Run: Start a container from an image.
+
+## Contributing
+
+- Use the `devcontainer.json` to open the repo in a dev container using VS Code.
+
+  - There is some test data in the `tests` directory that will be automatically mounted for use since the working directory is the workspace.
+  - Rebuild the container when you make changes using `Dev Container: Rebuild Container`.
+
+- Please make a new branch, starting with your name, with any changes, and request a reviewer before merging with the main branch since this image will be used by others.
+- Please document using the same conventions (docstrings for each function and class, typing-hints, informative comments).
+- Tests are written in the pytest framework. Data used in the tests are defined as fixtures in `tests/fixtures/data.py` (https://docs.pytest.org/en/6.2.x/reference.html#fixtures-api).
+
+## Build
+
+To build and push via automated CI, just push changes to a branch.
+
+- Pushes to `main` result in an image with the tag `latest`.
+- Pushes to other branches have tags with `-test` appended.
+- See `.github/workflows` for testing and production workflows.
+
+To test `test` images locally use after pushing the `test` images via CI:
+
+```
+docker pull ghcr.io/talmolab/lablink-latest-sleap-image:linux-amd64-test
+```
+
+then
+
+```
+docker run -v ./tests/data:/tests/data --gpus all -it ghcr.io/talmolab/lablink-latest-sleap-image:local-test bash
+```
+
+To build locally for testing you can use the command (from the root of the repo):
+
+```
+docker build --platform linux/amd64 ./lablink_sleap_latest_client
+```
+
+## Support
+
+contact Elizabeth at eberrigan@salk.edu


### PR DESCRIPTION
This pull request introduces new infrastructure and configuration files to support building, testing, and deploying the `lablink_sleap_latest_client` Docker image using GitHub Actions. It adds a production and a test workflow, a new Dockerfile for the client, a devcontainer configuration for development, and a `.dockerignore` file to optimize builds.

The most important changes are:

**GitHub Actions Workflows:**
* Added `.github/workflows/lablink_sleap_latest_client_production.yml` to build and push the production version of the `lablink-latest-sleap-client` Docker image on pushes to the `main` branch.
* Added `.github/workflows/lablink_sleap_latest_client_test.yml` to build and push test-tagged images for non-main branches, including steps to free disk space before building.

**Docker and Development Environment:**
* Added `lablink_sleap_latest_client/Dockerfile` to define the image build process, including setting up Python 3.11, installing `lablink-client-service` and `sleap[nn]` version 1.5.2, and using a base image.
* Added `lablink_sleap_latest_client/.devcontainer/devcontainer.json` to enable VSCode devcontainer support with GPU access and bash as the default shell.
* Added `lablink_sleap_latest_client/.dockerignore` to exclude unnecessary files and directories from Docker builds, improving build performance and security.